### PR TITLE
Dynomite static cluster configs

### DIFF
--- a/contribs/README.md
+++ b/contribs/README.md
@@ -1,0 +1,26 @@
+## Configuring a static Dynomite cluster
+
+In order to use a static dynomite cluster you must inform the cluster 
+topology in the properties file, with host, port, rack, datacenter and 
+token and load the ```StaticDynomiteClusterModule``` as configurations.
+
+```properties
+#Format is host:port:rack:datacenter:token separated by semicolon
+
+workflow.dynomite.cluster.hosts=host1:port:rack:datacenter:token1;host2:port:rack:datacenter:token2;host3:port:rack:datacenter:token3
+
+conductor.additional.modules=com.netflix.conductor.contribs.StaticDynomiteClusterModule
+```
+
+## Configuring cluster affinity
+
+In order to define the rack and datacenter affinity you must use the system properties 
+```LOCAL_RACK```, ```LOCAL_DATACENTER``` or ```EC2_AVAILABILITY_ZONE``` and```EC2_REGION```.
+
+```properties
+LOCAL_RACK=dc-rack1
+LOCAL_DATACENTER=dc
+# or
+EC2_AVAILABILITY_ZONE=us-east-1c
+EC2_REGION=us-east-1
+```

--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	
 	compile project(':conductor-common')
 	compile project(':conductor-core')
+	compile project(':conductor-redis-persistence')
 
 	compile 'com.amazonaws:aws-java-sdk-sqs:latest.release'
 	compile "com.google.inject:guice:${revGuice}"

--- a/contribs/src/main/java/com/netflix/conductor/contribs/DynomiteClusterModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/DynomiteClusterModule.java
@@ -1,0 +1,19 @@
+package com.netflix.conductor.contribs;
+
+import com.google.inject.AbstractModule;
+import com.netflix.conductor.contribs.dynomite.ConfigurationHostSupplierProvider;
+import com.netflix.conductor.contribs.dynomite.ConfigurationHostTokenSupplierProvider;
+import com.netflix.conductor.contribs.dynomite.HostTokenSupplier;
+import com.netflix.conductor.contribs.dynomite.TokenMapSupplierProvider;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.connectionpool.TokenMapSupplier;
+
+public class DynomiteClusterModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(HostTokenSupplier.class).toProvider(ConfigurationHostTokenSupplierProvider.class);
+        bind(HostSupplier.class).toProvider(ConfigurationHostSupplierProvider.class);
+        bind(TokenMapSupplier.class).toProvider(TokenMapSupplierProvider.class);
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/StaticDynomiteClusterModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/StaticDynomiteClusterModule.java
@@ -8,7 +8,7 @@ import com.netflix.conductor.contribs.dynomite.TokenMapSupplierProvider;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
 
-public class DynomiteClusterModule extends AbstractModule {
+public class StaticDynomiteClusterModule extends AbstractModule {
 
     @Override
     protected void configure() {

--- a/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostSupplierProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostSupplierProvider.java
@@ -1,0 +1,26 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.stream.Collectors;
+
+public class ConfigurationHostSupplierProvider implements Provider<HostSupplier> {
+    private final HostTokenSupplier hostTokenSupplier;
+
+    @Inject
+    public ConfigurationHostSupplierProvider(HostTokenSupplier hostTokenSupplier) {
+        this.hostTokenSupplier = hostTokenSupplier;
+    }
+
+    @Override
+    public HostSupplier get() {
+        return () -> hostTokenSupplier
+                .getHostsTokens()
+                .stream()
+                .map(HostToken::getHost)
+                .collect(Collectors.toList());
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostTokenSupplierProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostTokenSupplierProvider.java
@@ -1,0 +1,62 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+import com.netflix.conductor.dyno.DynomiteConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ConfigurationHostTokenSupplierProvider implements Provider<HostTokenSupplier> {
+    private static final String DELIMITER = ";";
+    private static Logger logger = LoggerFactory.getLogger(ConfigurationHostTokenSupplierProvider.class);
+
+    private final DynomiteConfiguration configuration;
+
+    @Inject
+    public ConfigurationHostTokenSupplierProvider(DynomiteConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public HostTokenSupplier get() {
+        return () -> parseHostsFromConfig(configuration);
+    }
+
+    private List<HostToken> parseHostsFromConfig(DynomiteConfiguration configuration) {
+        String hosts = configuration.getHosts();
+        if(hosts == null) {
+            // FIXME This type of validation probably doesn't belong here.
+            String message = String.format(
+                    "Missing dynomite/redis hosts.  Ensure '%s' has been set in the supplied configuration.",
+                    DynomiteConfiguration.HOSTS_PROPERTY_NAME
+            );
+            logger.error(message);
+            throw new RuntimeException(message);
+        }
+        return parseHostsFrom(hosts);
+    }
+
+    private List<HostToken> parseHostsFrom(String hostConfig){
+        List<String> hostConfigs = Arrays.asList(hostConfig.split(DELIMITER));
+
+        return hostConfigs.stream()
+                .map(this::buildHostToken)
+                .collect(Collectors.toList());
+    }
+
+    private HostToken buildHostToken(String hc) {
+        String[] hostConfigValues = hc.split(":");
+        String host = hostConfigValues[0];
+        int port = Integer.parseInt(hostConfigValues[1]);
+        String rack = hostConfigValues[2];
+        String datacenter = hostConfigValues[3];
+        Long token = Long.valueOf(hostConfigValues[4]);
+        return new HostToken(token, new Host(host, null, port, rack, datacenter, Host.Status.Up));
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostTokenSupplierProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostTokenSupplierProvider.java
@@ -31,7 +31,6 @@ public class ConfigurationHostTokenSupplierProvider implements Provider<HostToke
     private List<HostToken> parseHostsFromConfig(DynomiteConfiguration configuration) {
         String hosts = configuration.getHosts();
         if(hosts == null) {
-            // FIXME This type of validation probably doesn't belong here.
             String message = String.format(
                     "Missing dynomite/redis hosts.  Ensure '%s' has been set in the supplied configuration.",
                     DynomiteConfiguration.HOSTS_PROPERTY_NAME

--- a/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/HostTokenSupplier.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/HostTokenSupplier.java
@@ -1,0 +1,9 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.List;
+
+public interface HostTokenSupplier {
+    List<HostToken> getHostsTokens();
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/TokenMapSupplierProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/TokenMapSupplierProvider.java
@@ -1,0 +1,104 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.TokenMapSupplier;
+import com.netflix.dyno.connectionpool.impl.lb.AbstractTokenMapSupplier;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TokenMapSupplierProvider implements Provider<TokenMapSupplier> {
+    private final HostTokenSupplier hostTokenSupplier;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public TokenMapSupplierProvider(HostTokenSupplier hostTokenSupplier, ObjectMapper objectMapper) {
+        this.hostTokenSupplier = hostTokenSupplier;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public TokenMapSupplier get() {
+        return new StaticTopologyTokenMapSupplier(hostTokenSupplier.getHostsTokens(), objectMapper);
+    }
+
+    private static class StaticTopologyTokenMapSupplier extends AbstractTokenMapSupplier {
+
+        private final String jsonTopology;
+
+        StaticTopologyTokenMapSupplier(List<HostToken> hostTokens, ObjectMapper objectMapper) {
+            this.jsonTopology = convertToJson(buildTokenHosts(hostTokens), objectMapper);
+        }
+
+        @Override
+        public String getTopologyJsonPayload(Set<Host> activeHosts) {
+            return jsonTopology;
+        }
+
+        @Override
+        public String getTopologyJsonPayload(String hostname) {
+            return jsonTopology;
+        }
+
+        private List<TokenHost> buildTokenHosts(List<HostToken> hostTokens) {
+            return hostTokens.stream()
+                    .map(this::convertHostTokenToTokenHost)
+                    .collect(Collectors.toList());
+        }
+
+        private TokenHost convertHostTokenToTokenHost(HostToken hostToken) {
+            Host host = hostToken.getHost();
+            return new TokenHost(hostToken.getToken().toString(),
+                    host.getHostName(),
+                    host.getRack(),
+                    host.getDatacenter());
+        }
+
+        private String convertToJson(List<TokenHost> tokenHosts, ObjectMapper objectMapper) {
+            try {
+                return objectMapper.writeValueAsString(tokenHosts);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Error when generating dynomite json topology", e);
+            }
+        }
+    }
+
+    private static class TokenHost {
+        private String token;
+        private String hostname;
+        private String zone;
+        private String dc;
+
+        public TokenHost() {
+        }
+
+        TokenHost(String token, String hostname, String zone, String dc) {
+            this.token = token;
+            this.hostname = hostname;
+            this.zone = zone;
+            this.dc = dc;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public String getHostname() {
+            return hostname;
+        }
+
+        public String getZone() {
+            return zone;
+        }
+
+        public String getDc() {
+            return dc;
+        }
+    }
+}

--- a/contribs/src/main/resources/server.properties
+++ b/contribs/src/main/resources/server.properties
@@ -1,0 +1,51 @@
+#
+# Copyright 2017 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+db=dynomite
+
+#Dynomite Cluster details.
+#format is host:port:rack:datacenter:token separated by semicolon
+workflow.dynomite.cluster.hosts=host1:port:rack:datacenter:token1;host2:port:rack:datacenter:token2;host3:port:rack:datacenter:token3
+
+# Namespace for the keys stored in Dynomite/Redis
+workflow.namespace.prefix=conductor
+
+# Namespace prefix for the dyno queues
+workflow.namespace.queue.prefix=conductor_queues
+
+#no. of threads allocated to dyno-queues
+queues.dynomite.threads=10
+
+#non-quorum port used to connect to local redis.  Used by dyno-queues 
+queues.dynomite.nonQuorum.port=22122
+
+#Transport address to elasticsearch
+workflow.elasticsearch.url=localhost:9300
+workflow.elasticsearch.instanceType=external
+
+#Name of the elasticsearch cluster
+workflow.elasticsearch.index.name=conductor
+
+#Elasticsearch major release version.
+#workflow.elasticsearch.version=2
+
+# Load this module for static dynomite cluster
+conductor.additional.modules=com.netflix.conductor.contribs.StaticDynomiteClusterModule
+
+# Specify LOCAL_RACK and LOCAL_DATACENTER for rack and datacenter affinity
+LOCAL_RACK=dc-rack1
+LOCAL_DATACENTER=dc
+

--- a/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostSupplierProviderTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostSupplierProviderTest.java
@@ -1,0 +1,26 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfigurationHostSupplierProviderTest {
+
+    @Test
+    public void shouldReturnHostsFromHostTokenSupplier() {
+        HostTokenSupplier hostTokenSupplier = mock(HostTokenSupplier.class);
+        List<HostToken> hostTokens = HostTokenHelper.buildHostTokens();
+        when(hostTokenSupplier.getHostsTokens()).thenReturn(hostTokens);
+
+        List<Host> expectedHosts = hostTokens.stream().map(HostToken::getHost).collect(Collectors.toList());
+        ConfigurationHostSupplierProvider hostSupplier = new ConfigurationHostSupplierProvider(hostTokenSupplier);
+        assertEquals(expectedHosts, hostSupplier.get().getHosts());
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostTokenSupplierProviderTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/ConfigurationHostTokenSupplierProviderTest.java
@@ -1,0 +1,38 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.conductor.dyno.DynomiteConfiguration;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfigurationHostTokenSupplierProviderTest {
+
+    private DynomiteConfiguration configuration;
+
+    @Before
+    public void setUp() {
+        this.configuration = mock(DynomiteConfiguration.class);
+    }
+
+    @Test
+    public void shouldParseHostsWithTokenFromConfiguration() {
+        when(configuration.getHosts()).thenReturn(HostTokenHelper.buildHostTokensConfiguration());
+
+        ConfigurationHostTokenSupplierProvider hostTokenSupplier = new ConfigurationHostTokenSupplierProvider(configuration);
+        List<HostToken> expectedHostTokens = HostTokenHelper.buildHostTokens();
+        assertEquals(expectedHostTokens, hostTokenSupplier.get().getHostsTokens());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldThrownExceptionWhenHostsConfigurationIsNull() {
+        when(configuration.getHosts()).thenReturn(null);
+
+        new ConfigurationHostTokenSupplierProvider(configuration).get().getHostsTokens();
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/HostTokenHelper.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/HostTokenHelper.java
@@ -1,0 +1,42 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+
+import java.util.Arrays;
+import java.util.List;
+
+class HostTokenHelper {
+    private static final String HOST_1 = "host1";
+    private static final int PORT_1 = 8091;
+    private static final String RACK_1 = "rack1";
+    private static final String DATACENTER_1 = "datacenter1";
+    private static final long TOKEN_1 = 1383429731L;
+    private static final String HOST_2 = "host2";
+    private static final int PORT_2 = 8092;
+    private static final String RACK_2 = "rack2";
+    private static final String DATACENTER_2 = "datacenter2";
+    private static final String HOST_3 = "host3";
+    private static final int PORT_3 = 8093;
+    private static final String RACK_3 = "rack3";
+    private static final String DATACENTER_3 = "datacenter3";
+    private static final long TOKEN_2 = 1383429732L;
+    private static final long TOKEN_3 = 1383429733L;
+
+    static List<HostToken> buildHostTokens() {
+        Host host1 = new Host(HOST_1, null, PORT_1, RACK_1, DATACENTER_1, Host.Status.Up);
+        Host host2 = new Host(HOST_2, null, PORT_2, RACK_2, DATACENTER_2, Host.Status.Up);
+        Host host3 = new Host(HOST_3, null, PORT_3, RACK_3, DATACENTER_3, Host.Status.Up);
+        return Arrays.asList(
+                new HostToken(TOKEN_1, host1),
+                new HostToken(TOKEN_2, host2),
+                new HostToken(TOKEN_3, host3));
+    }
+
+    static String buildHostTokensConfiguration() {
+        return String.format("%s:%d:%s:%s:%d;%s:%d:%s:%s:%d;%s:%d:%s:%s:%d;",
+                HOST_1, PORT_1, RACK_1, DATACENTER_1, TOKEN_1,
+                HOST_2, PORT_2, RACK_2, DATACENTER_2, TOKEN_2,
+                HOST_3, PORT_3, RACK_3, DATACENTER_3, TOKEN_3);
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/TokenMapSupplierProviderTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/TokenMapSupplierProviderTest.java
@@ -1,0 +1,36 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.impl.lb.HostToken;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TokenMapSupplierProviderTest {
+
+    @Test
+    public void shouldBuildTokenMapSupplier() {
+        HostTokenSupplier hostTokenSupplier = mock(HostTokenSupplier.class);
+        List<HostToken> hostTokens = HostTokenHelper.buildHostTokens();
+        List<Host> hosts = hostTokens.stream().map(HostToken::getHost).collect(Collectors.toList());
+        when(hostTokenSupplier.getHostsTokens()).thenReturn(hostTokens);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        TokenMapSupplierProvider tokenMapSupplier = new TokenMapSupplierProvider(hostTokenSupplier, objectMapper);
+
+        Set<Host> activeHosts = hostTokens.stream().map(HostToken::getHost).collect(Collectors.toSet());
+
+        assertTrue(tokenMapSupplier.get().getTokens(activeHosts).containsAll(hostTokens));
+        assertEquals(hostTokens.get(0), tokenMapSupplier.get().getTokenForHost(hosts.get(0), activeHosts));
+        assertEquals(hostTokens.get(1), tokenMapSupplier.get().getTokenForHost(hosts.get(1), activeHosts));
+        assertEquals(hostTokens.get(2), tokenMapSupplier.get().getTokenForHost(hosts.get(2), activeHosts));
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/Configuration.java
@@ -50,6 +50,10 @@ public interface Configuration {
     String AVAILABILITY_ZONE_PROPERTY_NAME = "EC2_AVAILABILITY_ZONE";
     String AVAILABILITY_ZONE_DEFAULT_VALUE = "us-east-1c";
 
+    String LOCAL_RACK_PROPERTY_NAME = "LOCAL_RACK";
+
+    String LOCAL_DATACENTER_PROPERTY_NAME = "LOCAL_DATACENTER";
+
     String JERSEY_ENABLED_PROPERTY_NAME = "conductor.jersey.enabled";
     boolean JERSEY_ENABLED_DEFAULT_VALUE = true;
 

--- a/core/src/main/java/com/netflix/conductor/core/config/SystemPropertiesConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/SystemPropertiesConfiguration.java
@@ -80,11 +80,16 @@ public class SystemPropertiesConfiguration implements Configuration {
 
     @Override
     public String getRegion() {
-        return getProperty(REGION_PROPERTY_NAME, REGION_DEFAULT_VALUE);
+        String localDatacenter = getProperty(LOCAL_DATACENTER_PROPERTY_NAME, null);
+        return localDatacenter != null ? localDatacenter : getProperty(REGION_PROPERTY_NAME, REGION_DEFAULT_VALUE);
     }
 
     @Override
     public String getAvailabilityZone() {
+        String localRack = getProperty(LOCAL_RACK_PROPERTY_NAME, null);
+        if (localRack != null) {
+            return localRack;
+        }
         return getProperty(AVAILABILITY_ZONE_PROPERTY_NAME, AVAILABILITY_ZONE_DEFAULT_VALUE);
     }
 


### PR DESCRIPTION
Reason: Use a static dynomite datacenter cluster and configure the cluster topology, with host, port, rack, datacenter and token.

What has been done (contribs module):

* Creation of ```ConfigurationHostTokenSupplierProvider```, that reads the topology configuration from properties and creates a ```HostTokenSupplier```.
* Creation of ```StaticTokenMapSupplier```, that extends the existent ```AbstractTokenMapSupplier``` class and gets the topology from ```HostTokenSupplier```.
* Creation of ```StaticDynomiteClusterModule``` that overrides the current implementation for ```HostSupplier``` and ```TokenMapSupplier```.

What has been done (core module):

* New configuration properties: ```LOCAL_RACK``` and ```LOCAL_DATACENTER```. Used to replace ```EC2_AVAILABILITY_ZONE``` and ```EC2_REGION``` respectively, to define the rack and datacenter affinity. Obs: ```EC2_AVAILABILITY_ZONE``` and ```EC2_REGION``` properties are used as fallback.
