### PR TITLE
Dynoqueue configs for static dynomite cluster

### DIFF
--- a/contribs/src/main/java/com/netflix/conductor/contribs/StaticDynomiteClusterModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/StaticDynomiteClusterModule.java
@@ -1,7 +1,11 @@
 package com.netflix.conductor.contribs;
 
 import com.google.inject.AbstractModule;
-import com.netflix.conductor.contribs.dynomite.*;
+import com.netflix.conductor.contribs.dynomite.ConfigurationHostSupplierProvider;
+import com.netflix.conductor.contribs.dynomite.ConfigurationHostTokenSupplierProvider;
+import com.netflix.conductor.contribs.dynomite.HostTokenSupplier;
+import com.netflix.conductor.contribs.dynomite.TokenMapSupplierProvider;
+import com.netflix.conductor.contribs.dynomite.StaticDynoShardSupplierProvider;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
 import com.netflix.dyno.queues.ShardSupplier;

--- a/contribs/src/main/java/com/netflix/conductor/contribs/StaticDynomiteClusterModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/StaticDynomiteClusterModule.java
@@ -1,12 +1,10 @@
 package com.netflix.conductor.contribs;
 
 import com.google.inject.AbstractModule;
-import com.netflix.conductor.contribs.dynomite.ConfigurationHostSupplierProvider;
-import com.netflix.conductor.contribs.dynomite.ConfigurationHostTokenSupplierProvider;
-import com.netflix.conductor.contribs.dynomite.HostTokenSupplier;
-import com.netflix.conductor.contribs.dynomite.TokenMapSupplierProvider;
+import com.netflix.conductor.contribs.dynomite.*;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.connectionpool.TokenMapSupplier;
+import com.netflix.dyno.queues.ShardSupplier;
 
 public class StaticDynomiteClusterModule extends AbstractModule {
 
@@ -15,5 +13,6 @@ public class StaticDynomiteClusterModule extends AbstractModule {
         bind(HostTokenSupplier.class).toProvider(ConfigurationHostTokenSupplierProvider.class);
         bind(HostSupplier.class).toProvider(ConfigurationHostSupplierProvider.class);
         bind(TokenMapSupplier.class).toProvider(TokenMapSupplierProvider.class);
+        bind(ShardSupplier.class).toProvider(StaticDynoShardSupplierProvider.class);
     }
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/StaticDynoShardSupplierProvider.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/dynomite/StaticDynoShardSupplierProvider.java
@@ -1,0 +1,47 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.google.inject.ProvisionException;
+import com.netflix.conductor.dyno.DynomiteConfiguration;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.queues.ShardSupplier;
+import com.netflix.dyno.queues.shard.DynoShardSupplier;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StaticDynoShardSupplierProvider implements Provider<ShardSupplier> {
+
+    private final HostSupplier hostSupplier;
+    private final DynomiteConfiguration configuration;
+
+    @Inject
+    public StaticDynoShardSupplierProvider(HostSupplier hostSupplier, DynomiteConfiguration dynomiteConfiguration) {
+        this.hostSupplier = hostSupplier;
+        this.configuration = dynomiteConfiguration;
+    }
+
+    @Override
+    public ShardSupplier get() {
+        if(configuration.getAvailabilityZone() == null) {
+            throw new ProvisionException(
+                    "Availability zone is not defined.  Ensure Configuration.getAvailabilityZone() returns a non-null " +
+                            "and non-empty value."
+            );
+        }
+
+        String localDC = configuration.getAvailabilityZone().replaceAll(configuration.getRegion(), "");
+
+        return new DynoShardSupplier(this::getHostsFromAffinityRack, configuration.getRegion(), localDC);
+    }
+
+    private List<Host> getHostsFromAffinityRack() {
+        return hostSupplier.getHosts()
+                .stream()
+                .filter(host -> host.getRack().equals(configuration.getAvailabilityZone()))
+                .collect(Collectors.toList());
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/HostTokenHelper.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/HostTokenHelper.java
@@ -24,13 +24,18 @@ class HostTokenHelper {
     private static final long TOKEN_3 = 1383429733L;
 
     static List<HostToken> buildHostTokens() {
-        Host host1 = new Host(HOST_1, null, PORT_1, RACK_1, DATACENTER_1, Host.Status.Up);
-        Host host2 = new Host(HOST_2, null, PORT_2, RACK_2, DATACENTER_2, Host.Status.Up);
-        Host host3 = new Host(HOST_3, null, PORT_3, RACK_3, DATACENTER_3, Host.Status.Up);
+        List<Host> hosts = buildHosts();
         return Arrays.asList(
-                new HostToken(TOKEN_1, host1),
-                new HostToken(TOKEN_2, host2),
-                new HostToken(TOKEN_3, host3));
+                new HostToken(TOKEN_1, hosts.get(0)),
+                new HostToken(TOKEN_2, hosts.get(1)),
+                new HostToken(TOKEN_3, hosts.get(2)));
+    }
+
+    static List<Host> buildHosts() {
+        return Arrays.asList(
+                new Host(HOST_1, null, PORT_1, RACK_1, DATACENTER_1, Host.Status.Up),
+                new Host(HOST_2, null, PORT_2, RACK_2, DATACENTER_2, Host.Status.Up),
+                new Host(HOST_3, null, PORT_3, RACK_3, DATACENTER_3, Host.Status.Up));
     }
 
     static String buildHostTokensConfiguration() {

--- a/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/StaticDynoShardSupplierProviderTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/dynomite/StaticDynoShardSupplierProviderTest.java
@@ -1,0 +1,36 @@
+package com.netflix.conductor.contribs.dynomite;
+
+import com.netflix.conductor.dyno.DynomiteConfiguration;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StaticDynoShardSupplierProviderTest {
+
+    @Test
+    public void shouldGetShardsFromAvailabilityZone() {
+        HostSupplier hostSupplier = mock(HostSupplier.class);
+        DynomiteConfiguration configuration = mock(DynomiteConfiguration.class);
+
+        List<Host> hosts = HostTokenHelper.buildHosts();
+        String rack = hosts.get(1).getRack();
+        String dc = hosts.get(1).getDatacenter();
+
+        when(hostSupplier.getHosts()).thenReturn(hosts);
+        when(configuration.getAvailabilityZone()).thenReturn(rack);
+        when(configuration.getRegion()).thenReturn(dc);
+
+        StaticDynoShardSupplierProvider shardSupplier = new StaticDynoShardSupplierProvider(hostSupplier, configuration);
+
+        String expectedShard = rack.replaceAll(dc, "");
+        assertEquals(newHashSet(expectedShard), shardSupplier.get().getQueueShards());
+        assertEquals(expectedShard, shardSupplier.get().getCurrentShard());
+    }
+}


### PR DESCRIPTION
__Reason__: Use sharding based on rack affinity for dyno queues, so that each conductor instance will push and poll from the queue which name is created from the current shard (rack affinity).