### PR TITLE
Fixing conductor times for decision and fork tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1155,7 +1155,9 @@ public class WorkflowExecutor {
                 if (workflowSystemTask == null) {
                     throw new ApplicationException(NOT_FOUND, "No system task found by name " + task.getTaskType());
                 }
-                task.setStartTime(System.currentTimeMillis());
+                if (task.getStatus() != null && task.getStatus().isTerminal() && task.getStartTime() == 0) {
+                    task.setStartTime(System.currentTimeMillis());
+                }
                 if (!workflowSystemTask.isAsync()) {
                     try {
                         workflowSystemTask.start(workflow, task, this);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -87,6 +87,7 @@ public class DecisionTaskMapper implements TaskMapper {
         decisionTask.getInputData().put("case", caseValue);
         decisionTask.getOutputData().put("caseOutput", Collections.singletonList(caseValue));
         decisionTask.setTaskId(taskId);
+        decisionTask.setStartTime(System.currentTimeMillis());
         decisionTask.setStatus(Task.Status.IN_PROGRESS);
         decisionTask.setWorkflowTask(taskToSchedule);
         tasksToBeScheduled.add(decisionTask);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
@@ -74,7 +74,7 @@ public class ForkJoinTaskMapper implements TaskMapper {
         forkTask.setWorkflowType(workflowInstance.getWorkflowName());
         forkTask.setCorrelationId(workflowInstance.getCorrelationId());
         forkTask.setScheduledTime(System.currentTimeMillis());
-        forkTask.setEndTime(System.currentTimeMillis());
+        forkTask.setStartTime(System.currentTimeMillis());
         forkTask.setInputData(taskInput);
         forkTask.setTaskId(taskId);
         forkTask.setStatus(Task.Status.COMPLETED);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
@@ -65,6 +65,7 @@ public class JoinTaskMapper implements TaskMapper {
         joinTask.setCorrelationId(workflowInstance.getCorrelationId());
         joinTask.setWorkflowType(workflowInstance.getWorkflowName());
         joinTask.setScheduledTime(System.currentTimeMillis());
+        joinTask.setStartTime(System.currentTimeMillis());
         joinTask.setInputData(joinInput);
         joinTask.setTaskId(taskId);
         joinTask.setStatus(Task.Status.IN_PROGRESS);

--- a/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/dao/dynomite/RedisExecutionDAO.java
@@ -134,7 +134,9 @@ public class RedisExecutionDAO extends BaseDynoDAO implements ExecutionDAO {
 				continue;
 			}
 
-			task.setScheduledTime(System.currentTimeMillis());
+			if(task.getStatus() != null && !task.getStatus().isTerminal() && task.getScheduledTime() == 0){
+				task.setScheduledTime(System.currentTimeMillis());
+			}
 
 			correlateTaskToWorkflowInDS(task.getTaskId(), task.getWorkflowInstanceId());
 			logger.debug("Scheduled task added to WORKFLOW_TO_TASKS workflowId: {}, taskId: {}, taskType: {} during createTasks",

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -72,6 +72,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.COMPLETED;
@@ -3528,8 +3529,9 @@ public abstract class AbstractWorkflowServiceTest {
         assertEquals(RUNNING, es.getStatus());
         // Check the tasks, at this time there should be 3 task
         assertEquals(2, es.getTasks().size());
-        assertEquals(Status.SKIPPED, es.getTasks().get(0).getStatus());
-        assertEquals(SCHEDULED, es.getTasks().get(1).getStatus());
+
+        assertEquals(SCHEDULED, es.getTasks().stream().filter( task -> "t1".equals(task.getReferenceTaskName())).findFirst().orElse(null).getStatus());
+        assertEquals(Status.SKIPPED, es.getTasks().stream().filter( task -> "t2".equals(task.getReferenceTaskName())).findFirst().orElse(null).getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertNotNull(task);

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -81,7 +81,11 @@ import static com.netflix.conductor.common.metadata.tasks.Task.Status.IN_PROGRES
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.SCHEDULED;
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.TIMED_OUT;
 import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.RUNNING;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public abstract class AbstractWorkflowServiceTest {

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/AbstractWorkflowServiceTest.java
@@ -80,11 +80,7 @@ import static com.netflix.conductor.common.metadata.tasks.Task.Status.IN_PROGRES
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.SCHEDULED;
 import static com.netflix.conductor.common.metadata.tasks.Task.Status.TIMED_OUT;
 import static com.netflix.conductor.common.run.Workflow.WorkflowStatus.RUNNING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public abstract class AbstractWorkflowServiceTest {
@@ -3532,8 +3528,8 @@ public abstract class AbstractWorkflowServiceTest {
         assertEquals(RUNNING, es.getStatus());
         // Check the tasks, at this time there should be 3 task
         assertEquals(2, es.getTasks().size());
-        assertEquals(SCHEDULED, es.getTasks().get(0).getStatus());
-        assertEquals(Status.SKIPPED, es.getTasks().get(1).getStatus());
+        assertEquals(Status.SKIPPED, es.getTasks().get(0).getStatus());
+        assertEquals(SCHEDULED, es.getTasks().get(1).getStatus());
 
         Task task = workflowExecutionService.poll("junit_task_1", "task1.junit.worker");
         assertNotNull(task);
@@ -4253,6 +4249,110 @@ public abstract class AbstractWorkflowServiceTest {
         assertTrue(workflow.getOutput().isEmpty());
         assertNotNull(workflow.getExternalOutputPayloadStoragePath());
         assertEquals("workflow/output", workflow.getExternalOutputPayloadStoragePath());
+    }
+
+    @Test
+    public void testExecutionTimes(){
+
+        String taskName = "junit_task_1";
+        TaskDef taskDef = notFoundSafeGetTaskDef(taskName);
+        taskDef.setTimeoutSeconds(1);
+        metadataService.updateTaskDef(taskDef);
+
+        taskName = "junit_task_2";
+        taskDef = notFoundSafeGetTaskDef(taskName);
+        taskDef.setTimeoutSeconds(1);
+        metadataService.updateTaskDef(taskDef);
+
+        metadataService.registerTaskDef(Collections.singletonList(taskDef));
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("test_execution_times_wf");
+        workflowDef.setSchemaVersion(2);
+
+        WorkflowTask httpTask1 = new WorkflowTask();
+        httpTask1.setWorkflowTaskType(TaskType.HTTP);
+        httpTask1.setName("default");
+        httpTask1.setTaskReferenceName("http1");
+
+        WorkflowTask forkTask = new WorkflowTask();
+        forkTask.setType(TaskType.FORK_JOIN.name());
+        forkTask.setName("forktask1");
+        forkTask.setTaskReferenceName("forktask1");
+
+        WorkflowTask httpTask2 = new WorkflowTask();
+        httpTask2.setWorkflowTaskType(TaskType.HTTP);
+        httpTask2.setName("junit_task_1");
+        httpTask2.setTaskReferenceName("http2");
+
+        WorkflowTask httpTask3 = new WorkflowTask();
+        httpTask3.setWorkflowTaskType(TaskType.HTTP);
+        httpTask3.setName("junit_task_2");
+        httpTask3.setTaskReferenceName("http3");
+
+        forkTask.getForkTasks().add(Collections.singletonList(httpTask2));
+        forkTask.getForkTasks().add(Collections.singletonList(httpTask3));
+
+        WorkflowTask joinTask = new WorkflowTask();
+        joinTask.setType(TaskType.JOIN.name());
+        joinTask.setTaskReferenceName("jointask");
+        joinTask.setJoinOn(Arrays.asList("http2", "http3"));
+
+        Map<String, Object> decisionInputParameters = new HashMap<>();
+        decisionInputParameters.put("case", "a");
+
+        WorkflowTask decisionTask = new WorkflowTask();
+        decisionTask.setType(TaskType.DECISION.name());
+        decisionTask.setName("decision1");
+        decisionTask.setTaskReferenceName("decision1");
+        decisionTask.setInputParameters(decisionInputParameters);
+        decisionTask.setDefaultCase(Collections.singletonList(httpTask1));
+        decisionTask.setCaseValueParam("case");
+        Map<String, List<WorkflowTask>> decisionCases = new HashMap<>();
+        decisionCases.put("a", Arrays.asList(forkTask, joinTask));
+        decisionTask.setDecisionCases(decisionCases);
+
+        workflowDef.getTasks().add(decisionTask);
+
+        assertNotNull(workflowDef);
+
+        metadataService.registerWorkflowDef(workflowDef);
+
+        Map workflowInput = Collections.emptyMap();
+        String workflowId = startOrLoadWorkflowExecution(workflowDef.getName(), workflowDef.getVersion(), "test", workflowInput, null, null);
+        Workflow workflow = workflowExecutor.getWorkflow(workflowId, true);
+
+        assertNotNull(workflow);
+        assertEquals(5, workflow.getTasks().size());
+
+        Task task = workflowExecutionService.poll("HTTP", "test");
+        assertNotNull(task);
+        task.setStatus(Status.COMPLETED);
+        workflowExecutionService.updateTask(task);
+
+        task = workflowExecutionService.poll("HTTP", "test");
+        assertNotNull(task);
+        task.setStatus(Status.COMPLETED);
+        workflowExecutionService.updateTask(task);
+
+        workflowExecutor.decide(workflowId);
+        workflow = workflowExecutionService.getExecutionStatus(workflowId, true);
+        assertNotNull(workflow);
+        assertEquals(WorkflowStatus.COMPLETED, workflow.getStatus());
+
+        workflow.getTasks().forEach( workflowTask -> {
+            assertTrue(workflowTask.getScheduledTime() <= workflowTask.getStartTime());
+            assertTrue(workflowTask.getStartTime() < workflowTask.getEndTime());
+        });
+
+        assertEquals("decision1", workflow.getTasks().get(0).getReferenceTaskName());
+        assertEquals("forktask1", workflow.getTasks().get(1).getReferenceTaskName());
+        assertEquals("http2", workflow.getTasks().get(2).getReferenceTaskName());
+        assertEquals("http3", workflow.getTasks().get(3).getReferenceTaskName());
+        assertEquals("jointask", workflow.getTasks().get(4).getReferenceTaskName());
+
+        metadataService.unregisterWorkflowDef(workflowDef.getName(), 1);
+
     }
 
     @Test

--- a/test-harness/src/test/java/com/netflix/conductor/tests/integration/WorkflowLegacyMigrationTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/tests/integration/WorkflowLegacyMigrationTest.java
@@ -118,4 +118,10 @@ public class WorkflowLegacyMigrationTest extends AbstractWorkflowServiceTest {
      */
     public void testForkJoinNestedWithSubWorkflow() {
     }
+
+    @Ignore
+    @Test
+    @Override
+    public void testExecutionTimes(){}
+
 }


### PR DESCRIPTION
Fixing conductor conditions to set or update scheduled, start and endtime of decision and fork-join tasks